### PR TITLE
Add compatibility with offsite gateways

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -53,7 +53,7 @@ function pmprosla_pmpro_after_checkout( $user_id, $order ) {
 		) );
 		if ( is_wp_error( $response ) ) {
 			$error_message = $response->get_error_message();
-			echo 'Something went wrong: $error_message';
+			echo 'Something went wrong: ' . esc_html( $error_message );
 		}
 
 		/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -26,36 +26,34 @@ function pmprosla_pmpro_after_checkout( $user_id, $order ) {
 
 	// Check that webhook exists in the settings page.
 	if ( '' !== $webhook_url ) {
-		if ( is_user_logged_in() ) {
-			$payload = array(
-				'text'        => 'New checkout: ' . $current_user->user_email,
-				'username'    => 'PMProBot',
-				'icon_emoji'  => ':credit_card:',
-				'blocks'      => array(
-					array(
-						'type' => 'section',
-						'text' => array(
-							'type' => 'mrkdwn',
-							'text' => '*New checkout: ' . $current_user->user_email . '*',
-						),
-					),
-					array(
-						'type' => 'section',
-						'text' => array(
-							'type' => 'mrkdwn',
-							'text' => '>' . $current_user->display_name . ' has checked out for ' . $level->name . ' ($' . $level->initial_payment . ')',
-						),
+		$payload = array(
+			'text'        => 'New checkout: ' . $current_user->user_email,
+			'username'    => 'PMProBot',
+			'icon_emoji'  => ':credit_card:',
+			'blocks'      => array(
+				array(
+					'type' => 'section',
+					'text' => array(
+						'type' => 'mrkdwn',
+						'text' => '*New checkout: ' . $current_user->user_email . '*',
 					),
 				),
-			);
-			$output   = 'payload=' . wp_json_encode( $payload );
-			$response = wp_remote_post( $webhook_url, array(
-				'body' => $output,
-			) );
-			if ( is_wp_error( $response ) ) {
-				$error_message = $response->get_error_message();
-				echo 'Something went wrong: $error_message';
-			}
+				array(
+					'type' => 'section',
+					'text' => array(
+						'type' => 'mrkdwn',
+						'text' => '>' . $current_user->display_name . ' has checked out for ' . $level->name . ' ($' . $level->initial_payment . ')',
+					),
+				),
+			),
+		);
+		$output   = 'payload=' . wp_json_encode( $payload );
+		$response = wp_remote_post( $webhook_url, array(
+			'body' => $output,
+		) );
+		if ( is_wp_error( $response ) ) {
+			$error_message = $response->get_error_message();
+			echo 'Something went wrong: $error_message';
 		}
 
 		/**


### PR DESCRIPTION
Removing requirement for users to be logged in for the Slack notification to be sent. This was preventing notifications from being sent for gateways such as Stripe Checkout where the checkout confirmation is handled asynchronously by the webhook handler.