### PR TITLE
Localize settings page and fix textdomain on plugin row links

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -58,8 +58,8 @@ add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'pmprosla_plug
 function pmprosla_plugin_row_meta( $links, $file ) {
 	if ( strpos( $file, 'pmpro-slack.php' ) !== false ) {
 		$new_links = array(
-			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-slack-integration/' ) . '" title="' . esc_attr( __( 'View Documentation', 'pmpro' ) ) . '">' . __( 'Docs', 'pmpro' ) . '</a>',
-			'<a href="' . esc_url( 'https://paidmembershipspro.com/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro' ) ) . '">' . __( 'Support', 'pmpro' ) . '</a>',
+			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-slack-integration/' ) . '" title="' . esc_attr__( 'View Documentation', 'pmpro-slack' ) . '">' . esc_html__( 'Docs', 'pmpro-slack' ) . '</a>',
+			'<a href="' . esc_url( 'https://paidmembershipspro.com/support/' ) . '" title="' . esc_attr__( 'Visit Customer Support Forum', 'pmpro-slack' ) . '">' . esc_html__( 'Support', 'pmpro-slack' ) . '</a>',
 		);
 		$links = array_merge( $links, $new_links );
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -53,7 +53,11 @@ function pmprosla_pmpro_after_checkout( $user_id, $order ) {
 		) );
 		if ( is_wp_error( $response ) ) {
 			$error_message = $response->get_error_message();
-			echo 'Something went wrong: ' . esc_html( $error_message );
+			printf(
+				/* translators: %s: error message returned from the Slack webhook request. */
+				esc_html__( 'Something went wrong: %s', 'pmpro-slack' ),
+				esc_html( $error_message )
+			);
 		}
 
 		/**

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -24,7 +24,7 @@ function pmprosla_integration_options_page() {
 	?>
 	<div class="wrap">
 		<?php require_once( PMPRO_DIR . '/adminpages/admin_header.php' ); ?>
-		<h1><?php esc_attr_e( 'Paid Memberships Pro - Slack Integration Add On', 'pmpro-slack' ); ?></h1>
+		<h1><?php esc_html_e( 'Paid Memberships Pro - Slack Integration Add On', 'pmpro-slack' ); ?></h1>
 		<form action="options.php" method="POST">
 			<?php settings_fields( 'pmpro-slack-group' ); ?>
 			<?php do_settings_sections( 'pmpro-slack' ); ?>
@@ -41,7 +41,7 @@ add_action( 'admin_init', 'pmprosla_admin_init' );
  */
 function pmprosla_admin_init() {
 	register_setting( 'pmpro-slack-group', 'pmprosla_data', 'pmprosla_validate' );
-	add_settings_section( 'pmpro-slack-notifications', 'Slack Checkout Notifications', 'pmprosla_notications_callback', 'pmpro-slack' );
+	add_settings_section( 'pmpro-slack-notifications', __( 'Slack Checkout Notifications', 'pmpro-slack' ), 'pmprosla_notications_callback', 'pmpro-slack' );
 }
 
 
@@ -49,23 +49,30 @@ function pmprosla_admin_init() {
  * Sets up settings for Slack notifications on checkout
  */
 function pmprosla_notications_callback() {
-	$options = pmprosla_get_options();
-	$levels = pmpro_getAllLevels( true, true );
-	echo '<ol>
-		<li>Go To <a target="_blank" href="https://slack.com/services/new/incoming-webhook">https://slack.com/services/new/incoming-webhook</a> and create a new webhook</li>
-		<li>Enter created webhook URL here: <input type="url" id="webhook" name="pmprosla_data[webhook]" value="' . esc_url( $options['webhook'] ) . '" /></li>
-		<li>Choose levels to send notifications for:<br/>
-		<select multiple="yes" name="pmprosla_data[levels_to_notify][]"" style="width:500px" id="pmpro_sla_levels_select">';
+	$options     = pmprosla_get_options();
+	$levels      = pmpro_getAllLevels( true, true );
+	$webhook_url = 'https://slack.com/services/new/incoming-webhook';
+	echo '<ol>';
+	echo '<li>';
+	printf(
+		/* translators: %s: link to Slack's incoming-webhook creation page. */
+		esc_html__( 'Go to %s and create a new webhook.', 'pmpro-slack' ),
+		'<a target="_blank" href="' . esc_url( $webhook_url ) . '">' . esc_html( $webhook_url ) . '</a>'
+	);
+	echo '</li>';
+	echo '<li>' . esc_html__( 'Enter created webhook URL here:', 'pmpro-slack' ) . ' <input type="url" id="webhook" name="pmprosla_data[webhook]" value="' . esc_url( $options['webhook'] ) . '" /></li>';
+	echo '<li>' . esc_html__( 'Choose levels to send notifications for:', 'pmpro-slack' ) . '<br/>';
+	echo '<select multiple="yes" name="pmprosla_data[levels_to_notify][]" style="width:500px" id="pmpro_sla_levels_select">';
 	foreach ( $levels as $level ) {
-		echo '<option value="' . $level->id . '" ';
+		echo '<option value="' . esc_attr( $level->id ) . '" ';
 		if ( ! empty( $options['levels_to_notify'] ) && in_array( $level->id, $options['levels_to_notify'] ) ) {
 			echo 'selected="selected"';
 		}
-		echo '>' . $level->name . '</option>';
+		echo '>' . esc_html( $level->name ) . '</option>';
 	}
-		echo '</select></li>
-		<li>Click `Save Changes`</li>
-		</ol>';
+	echo '</select></li>';
+	echo '<li>' . esc_html__( 'Click `Save Changes`.', 'pmpro-slack' ) . '</li>';
+	echo '</ol>';
 		?>
 		<script>
 			jQuery( document ).ready(function() {


### PR DESCRIPTION
## Summary

Fixes a handful of localization gaps and a couple of pre-existing escaping/markup bugs in the Settings page and plugin row links.

### Localization
- **`includes/admin.php`** — The "Docs" / "Support" plugin row links were using textdomain `'pmpro'` instead of the plugin's own `'pmpro-slack'`. Strings under the wrong domain are silently un-translatable for this plugin. Fixed all 4 occurrences and switched to `esc_attr__` / `esc_html__` for the title attrs and link labels.
- **`includes/settings.php`**
  - The page H1 was using `esc_attr_e` for body content — switched to `esc_html_e`.
  - Settings section title `'Slack Checkout Notifications'` (passed to `add_settings_section`) was hardcoded English; now wrapped in `__()`.
  - The `<ol>` instructional block (the four "how to set up the webhook" steps) was hardcoded English. Split into per-string `esc_html__()` calls. The Slack webhook URL is interpolated via `printf( ... %s ... )` with a pre-built `<a>` tag so translators get one clean sentence.
- **`includes/functions.php`** — The `wp_remote_post` failure `echo` is now wrapped in `esc_html__` + `printf` so the error message is translatable.

### Pre-existing bugs cleaned up while in the area
- **Stray double-quote** in `name="pmprosla_data[levels_to_notify][]""` (extra `"` produced invalid HTML on the Settings page).
- **Unescaped output** in the levels-to-notify `<select>`: `<option value="$level->id">$level->name</option>` now runs through `esc_attr()` and `esc_html()` respectively.

## Test plan
- [ ] Activate the plugin and visit **Settings → PMPro Slack**. Confirm the page heading, the section title, the four-step instructions, and the levels dropdown all render normally in English.
- [ ] In the **Plugins** list, hover the "Docs" and "Support" links under PMPro Slack — confirm the title attribute tooltips render.
- [ ] With a non-English locale active (e.g. via Loco Translate or a `.mo` for `pmpro-slack`), confirm all strings on the settings page and the plugin-row links pick up the translation.
- [ ] Trigger a webhook failure (e.g. set the webhook URL to an invalid host) and complete a checkout that runs `pmpro_after_checkout`; confirm the "Something went wrong: …" message is now translatable and that `$error_message` actually appears.
- [ ] View page source on the Settings page and confirm there is no stray `""` in the `<select>` `name` attribute.
